### PR TITLE
move nonce to accounts table

### DIFF
--- a/verifier/verifier.abi
+++ b/verifier/verifier.abi
@@ -1,7 +1,29 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Thu Jan 31 16:32:27 2019",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Tue Mar  5 22:38:12 2019",
     "version": "eosio::abi/1.1",
     "structs": [
+        {
+            "name": "account",
+            "base": "",
+            "fields": [
+                {
+                    "name": "key",
+                    "type": "uint64"
+                },
+                {
+                    "name": "publickey",
+                    "type": "public_key"
+                },
+                {
+                    "name": "balance",
+                    "type": "asset"
+                },
+                {
+                    "name": "last_nonce",
+                    "type": "uint64"
+                }
+            ]
+        },
         {
             "name": "create",
             "base": "",
@@ -13,6 +35,24 @@
                 {
                     "name": "maximum_supply",
                     "type": "asset"
+                }
+            ]
+        },
+        {
+            "name": "currstats",
+            "base": "",
+            "fields": [
+                {
+                    "name": "supply",
+                    "type": "asset"
+                },
+                {
+                    "name": "max_supply",
+                    "type": "asset"
+                },
+                {
+                    "name": "issuer",
+                    "type": "name"
                 }
             ]
         },
@@ -71,33 +111,6 @@
                     "type": "signature"
                 }
             ]
-        },
-        {
-            "name": "account",
-            "base": "",
-            "fields": [
-                {"name":"key", "type":"uint64"},
-                {"name":"publickey", "type":"public_key"},
-                {"name":"balance", "type":"asset"},
-            ]
-        },
-        {
-            "name": "currstats",
-            "base": "",
-            "fields": [
-                {"name":"supply", "type":"asset"},
-                {"name":"max_supply", "type":"asset"},
-                {"name":"issuer", "type":"name"}
-            ]
-        },
-        {
-            "name": "nonce",
-            "base": "",
-            "fields": [
-                {"name":"id", "type":"uint64"},
-                {"name":"publickey", "type":"public_key"},
-                {"name":"last_nonce", "type":"uint64"}
-            ]
         }
     ],
     "types": [],
@@ -118,25 +131,22 @@
             "ricardian_contract": ""
         }
     ],
-    "tables": [{
-        "name": "accounts",
-        "type": "account",
-        "index_type": "i64",
-        "key_names" : ["key"],
-        "key_types" : ["uint64"]
-    }, {
-        "name": "stats",
-        "type": "currstats",
-        "index_type": "i64",
-        "key_names" : ["currency"],
-        "key_types" : ["uint64"]
-    }, {
-        "name": "nonces",
-        "type": "nonce",
-        "index_type": "i64",
-        "key_names" : ["id"],
-        "key_types" : ["uint64"]
-    }],
+    "tables": [
+        {
+            "name": "accounts",
+            "type": "account",
+            "index_type": "i64",
+            "key_names": [],
+            "key_types": []
+        },
+        {
+            "name": "stats",
+            "type": "currstats",
+            "index_type": "i64",
+            "key_names": [],
+            "key_types": []
+        }
+    ],
     "ricardian_clauses": [],
     "variants": [],
     "abi_extensions": []

--- a/verifier/verifier.abi
+++ b/verifier/verifier.abi
@@ -136,15 +136,15 @@
             "name": "accounts",
             "type": "account",
             "index_type": "i64",
-            "key_names": [],
-            "key_types": []
+            "key_names": ["key"],
+            "key_types": ["key"]
         },
         {
             "name": "stats",
             "type": "currstats",
             "index_type": "i64",
-            "key_names": [],
-            "key_types": []
+            "key_names": ["currency"],
+            "key_types": ["key"]
         }
     ],
     "ricardian_clauses": [],

--- a/verifier/verifier.abi
+++ b/verifier/verifier.abi
@@ -137,14 +137,14 @@
             "type": "account",
             "index_type": "i64",
             "key_names": ["key"],
-            "key_types": ["key"]
+            "key_types": ["uint64"]
         },
         {
             "name": "stats",
             "type": "currstats",
             "index_type": "i64",
             "key_names": ["currency"],
-            "key_types": ["key"]
+            "key_types": ["uint64"]
         }
     ],
     "ricardian_clauses": [],

--- a/verifier/verifier.hpp
+++ b/verifier/verifier.hpp
@@ -7,8 +7,9 @@
 using namespace eosio;
 using namespace std;
 
-class verifier : public contract {
-  public:
+class [[eosio::contract]] verifier : public eosio::contract {
+
+public:
     using contract::contract;
 
     [[eosio::action]]
@@ -32,6 +33,7 @@ class verifier : public contract {
       uint64_t key;
       public_key publickey;
       asset balance;
+      uint64_t last_nonce;
 
       uint64_t primary_key() const { return key; }
       fixed_bytes<32> bypk() const {
@@ -47,28 +49,12 @@ class verifier : public contract {
         uint64_t primary_key() const { return supply.symbol.raw(); }
     };
 
-    struct [[eosio::table]] nonce {
-        uint64_t id;
-        public_key publickey;
-        uint64_t last_nonce;
-
-        uint64_t primary_key() const { return id; }
-        fixed_bytes<32> bypk() const {
-            return public_key_to_fixed_bytes(publickey);
-        };
-    };
-
     typedef eosio::multi_index<"accounts"_n,
                                account,
                                indexed_by<"bypk"_n, const_mem_fun<account, fixed_bytes<32>, &account::bypk>>
                               > accounts;
 
     typedef eosio::multi_index<"stats"_n, currstats> stats;
-
-    typedef eosio::multi_index<"nonces"_n,
-                               nonce,
-                               indexed_by<"bypk"_n, const_mem_fun<nonce, fixed_bytes<32>, &nonce::bypk>>
-                              > nonces;
 
   private:
 


### PR DESCRIPTION
Moves the last_nonce field from its own table into the accounts table. This was a design oversight when initially coding the feature and results in no changes to the features or functionality of the contract. 